### PR TITLE
chore: define AGENTS.md for Copilot agent routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Copilot Agent Instructions
+
+## Project Management (GitHub Scrum)
+
+When working with pull requests, issues, milestones, sprints, labels, releases, retrospectives, backlog management, or any other aspect of project management on GitHub, use the **github-scrum** skill located at `skills/github-scrum/SKILL.md`.
+
+## Documentation (Pragmatic Docs)
+
+When creating, editing, or reviewing documentation — including README files, module docs, guides, CONTRIBUTING.md, or any content under `docs/` — use the **pragmatic-docs** skill located at `skills/pragmatic-docs/SKILL.md`.


### PR DESCRIPTION
## Summary

Configure GitHub Copilot agent routing by adding `AGENTS.md` at the repository root.

## Changes

- **Project Management**: Routes issues, PRs, milestones, sprints, labels, releases, and retrospectives to the `github-scrum` skill.
- **Documentation**: Routes README, guides, CONTRIBUTING.md, and `docs/` content to the `pragmatic-docs` skill.

## Linked Issue

Closes #8

## Checklist

- [x] `AGENTS.md` created at repo root
- [x] `github-scrum` skill referenced for project management
- [x] `pragmatic-docs` skill referenced for documentation"