### PR TITLE
fix: grant contents:write permission to Release Drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,7 +7,7 @@ on:
     types: [opened, reopened, synchronize]
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
## Summary

The Release Drafter workflow fails with a **403 Resource not accessible by integration** error when attempting to create a draft release.

## Root Cause

The workflow declared `contents: read`, but the `release-drafter/release-drafter@v6` action needs `contents: write` to create releases via the GitHub API.

## Fix

Changed `contents: read` → `contents: write` in the workflow permissions block.

Closes #10