### PR TITLE
feat(github-scrum): prefer MCP tools over gh CLI, add GH_PAGER=cat

### DIFF
--- a/skills/github-scrum/SKILL.md
+++ b/skills/github-scrum/SKILL.md
@@ -1,13 +1,47 @@
 ---
 name: github-scrum
-description: Manage software projects with Scrum on GitHub. Plan MVPs, maintain a Product Backlog as Issues, run Sprints as Milestones, and automate setup with gh CLI. Adapted for solo developers and small teams (1-3 people).
+description: Manage software projects with Scrum on GitHub. Plan MVPs, maintain a Product Backlog as Issues, run Sprints as Milestones, and automate setup with GitHub MCP tools (preferred) or gh CLI (fallback). Adapted for solo developers and small teams (1-3 people).
 ---
 
 # GitHub Scrum
 
-Manage software projects using Scrum on GitHub, adapted for solo developers and small teams (1-3 people). This skill maps Scrum artifacts and events to GitHub primitives (Issues, Milestones, Labels, Releases) and automates project setup and sprint management using `gh` CLI.
+Manage software projects using Scrum on GitHub, adapted for solo developers and small teams (1-3 people). This skill maps Scrum artifacts and events to GitHub primitives (Issues, Milestones, Labels, Releases) and automates project setup and sprint management.
 
 Reference: [The 2020 Scrum Guide](https://scrumguides.org/scrum-guide.html).
+
+---
+
+## Tooling Strategy
+
+**Prefer GitHub MCP tools** (`mcp_github_github_*`) for all operations they support. Fall back to the `gh` CLI **only** when the MCP server does not expose the needed functionality.
+
+### When to use MCP tools (preferred)
+
+The GitHub MCP server supports:
+
+- **Issues:** create, read, update (labels, milestone, state, body), list, search, add comments, sub-issues
+- **Pull Requests:** create, read, update, list, search, merge, review
+- **Branches:** create, list
+- **Releases:** list, get latest, get by tag
+- **Labels:** get a single label
+- **Files:** create/update, delete, push multiple files
+- **Commits:** get, list
+- **Repository:** create, search, fork, get file contents
+
+### When to use `gh` CLI (fallback)
+
+The MCP server does **not** support these operations — use `gh` CLI instead:
+
+- **Labels:** create, delete, list all labels
+- **Milestones:** create, update, close, list (use `gh api`)
+- **Releases:** create new releases
+- **Any advanced GitHub API call** not covered by MCP tools
+
+> **IMPORTANT:** Always set `GH_PAGER=cat` when running `gh` commands to prevent interactive pagers from blocking script execution.
+>
+> ```sh
+> GH_PAGER=cat gh issue list ...
+> ```
 
 ---
 
@@ -94,48 +128,66 @@ Use the answer as:
 - The repository description (if creating a new repo)
 - A pinned issue titled **Product Goal** with the full vision
 
+**Using MCP (preferred):**
+
+Use `mcp_github_github_issue_write` to create the issue:
+
+```
+tool: mcp_github_github_issue_write
+params:
+  owner: <owner>
+  repo: <repo>
+  title: "Product Goal"
+  body: "## Vision\n\n<user's answer>\n\n## Target Users\n\n<who benefits>\n\n## Success Criteria\n\n- [ ] <measurable outcome>"
+  labels: ["type:docs"]
+```
+
+Then pin the issue via `gh` CLI (MCP does not support pinning):
+
 ```sh
-gh issue create --title "Product Goal" --body "## Vision\n\n<user's answer>\n\n## Target Users\n\n<who benefits>\n\n## Success Criteria\n\n- [ ] <measurable outcome>" --label "type:docs" --pinned
+GH_PAGER=cat gh issue pin <issue-number>
 ```
 
 ### 2. Create Labels
 
-Delete GitHub's default labels and create the Scrum label set:
+Delete GitHub's default labels and create the Scrum label set.
+
+> **Note:** The MCP server does not support label creation or deletion. Use `gh` CLI with `GH_PAGER=cat`.
 
 ```sh
 # Remove default labels
-gh label list --json name -q '.[].name' | xargs -I {} gh label delete {} --yes
+GH_PAGER=cat gh label list --json name -q '.[].name' | xargs -I {} GH_PAGER=cat gh label delete {} --yes
 
 # Type labels
-gh label create "type:feature" --color "1D76DB" --description "New functionality"
-gh label create "type:bug" --color "D73A4A" --description "Something isn't working"
-gh label create "type:chore" --color "0E8A16" --description "Maintenance, refactoring, tooling"
-gh label create "type:spike" --color "D4C5F9" --description "Research or investigation (timeboxed)"
-gh label create "type:docs" --color "0075CA" --description "Documentation only"
+GH_PAGER=cat gh label create "type:feature" --color "1D76DB" --description "New functionality"
+GH_PAGER=cat gh label create "type:bug" --color "D73A4A" --description "Something isn't working"
+GH_PAGER=cat gh label create "type:chore" --color "0E8A16" --description "Maintenance, refactoring, tooling"
+GH_PAGER=cat gh label create "type:spike" --color "D4C5F9" --description "Research or investigation (timeboxed)"
+GH_PAGER=cat gh label create "type:docs" --color "0075CA" --description "Documentation only"
 
 # Priority labels
-gh label create "priority:critical" --color "B60205" --description "Must fix immediately — blocks everything"
-gh label create "priority:high" --color "D93F0B" --description "Must be in the next sprint"
-gh label create "priority:medium" --color "FBCA04" --description "Should be done soon"
-gh label create "priority:low" --color "C2E0C6" --description "Nice to have, do when possible"
+GH_PAGER=cat gh label create "priority:critical" --color "B60205" --description "Must fix immediately — blocks everything"
+GH_PAGER=cat gh label create "priority:high" --color "D93F0B" --description "Must be in the next sprint"
+GH_PAGER=cat gh label create "priority:medium" --color "FBCA04" --description "Should be done soon"
+GH_PAGER=cat gh label create "priority:low" --color "C2E0C6" --description "Nice to have, do when possible"
 
 # Size labels
-gh label create "size:xs" --color "EDEDED" --description "Trivial — less than 1 hour"
-gh label create "size:s" --color "D4C5F9" --description "Small — 1 to 4 hours"
-gh label create "size:m" --color "BFD4F2" --description "Medium — 4 to 8 hours"
-gh label create "size:l" --color "FBCA04" --description "Large — 1 to 2 days"
-gh label create "size:xl" --color "D93F0B" --description "Extra large — more than 2 days (split it)"
+GH_PAGER=cat gh label create "size:xs" --color "EDEDED" --description "Trivial — less than 1 hour"
+GH_PAGER=cat gh label create "size:s" --color "D4C5F9" --description "Small — 1 to 4 hours"
+GH_PAGER=cat gh label create "size:m" --color "BFD4F2" --description "Medium — 4 to 8 hours"
+GH_PAGER=cat gh label create "size:l" --color "FBCA04" --description "Large — 1 to 2 days"
+GH_PAGER=cat gh label create "size:xl" --color "D93F0B" --description "Extra large — more than 2 days (split it)"
 
 # Status labels
-gh label create "status:ready" --color "0E8A16" --description "Refined and ready for sprint selection"
-gh label create "status:in-progress" --color "1D76DB" --description "Currently being worked on"
-gh label create "status:blocked" --color "B60205" --description "Waiting on something external"
-gh label create "status:review" --color "D4C5F9" --description "In code review or waiting for feedback"
+GH_PAGER=cat gh label create "status:ready" --color "0E8A16" --description "Refined and ready for sprint selection"
+GH_PAGER=cat gh label create "status:in-progress" --color "1D76DB" --description "Currently being worked on"
+GH_PAGER=cat gh label create "status:blocked" --color "B60205" --description "Waiting on something external"
+GH_PAGER=cat gh label create "status:review" --color "D4C5F9" --description "In code review or waiting for feedback"
 
 # Special labels
-gh label create "mvp" --color "FEF2C0" --description "Part of the Minimum Viable Product"
-gh label create "tech-debt" --color "E4E669" --description "Technical debt — address proactively"
-gh label create "retrospective" --color "C5DEF5" --description "Sprint retrospective issue"
+GH_PAGER=cat gh label create "mvp" --color "FEF2C0" --description "Part of the Minimum Viable Product"
+GH_PAGER=cat gh label create "tech-debt" --color "E4E669" --description "Technical debt — address proactively"
+GH_PAGER=cat gh label create "retrospective" --color "C5DEF5" --description "Sprint retrospective issue"
 ```
 
 ### 3. Identify the MVP
@@ -151,8 +203,22 @@ Guide the user to keep the MVP as small as possible — typically 3-7 features. 
 
 Create each backlog item as an issue:
 
+**Using MCP (preferred):**
+
+```
+tool: mcp_github_github_issue_write
+params:
+  owner: <owner>
+  repo: <repo>
+  title: "<feature title>"
+  body: "## Description\n\n<what and why>\n\n## Acceptance Criteria\n\n- [ ] <criterion 1>\n- [ ] <criterion 2>\n- [ ] <criterion 3>\n\n## Notes\n\n<technical notes, constraints, dependencies>"
+  labels: ["type:feature", "priority:high", "size:m", "mvp"]
+```
+
+**Using `gh` CLI (fallback):**
+
 ```sh
-gh issue create \
+GH_PAGER=cat gh issue create \
   --title "<feature title>" \
   --body "## Description\n\n<what and why>\n\n## Acceptance Criteria\n\n- [ ] <criterion 1>\n- [ ] <criterion 2>\n- [ ] <criterion 3>\n\n## Notes\n\n<technical notes, constraints, dependencies>" \
   --label "type:feature,priority:high,size:m,mvp"
@@ -162,21 +228,35 @@ Always include **Acceptance Criteria** as a checklist — these are the concrete
 
 ### 4. Create the First Sprint
 
-Create a milestone for Sprint 1. Recommend 1-week sprints for solo developers, 2-week for small teams:
+Create a milestone for Sprint 1. Recommend 1-week sprints for solo developers, 2-week for small teams.
+
+> **Note:** The MCP server does not support milestones. Use `gh api` with `GH_PAGER=cat`.
 
 ```sh
 # Create milestone (Sprint 1)
-gh api repos/{owner}/{repo}/milestones --method POST \
+GH_PAGER=cat gh api repos/{owner}/{repo}/milestones --method POST \
   --field title="Sprint 1" \
   --field description="Sprint Goal: <what makes this sprint valuable>" \
   --field due_on="<ISO 8601 date, e.g. 2026-03-06T23:59:59Z>"
 ```
 
-Select issues for the sprint based on priority and capacity. For a 1-week sprint, aim for issues totaling roughly 20-30 hours of estimated work (adjust based on available time):
+Select issues for the sprint based on priority and capacity. For a 1-week sprint, aim for issues totaling roughly 20-30 hours of estimated work (adjust based on available time).
+
+**Using MCP (preferred) — assign issues to the sprint milestone:**
+
+```
+tool: mcp_github_github_issue_write
+params:
+  owner: <owner>
+  repo: <repo>
+  issue_number: <issue-number>
+  milestone: <milestone-number>
+```
+
+**Using `gh` CLI (fallback):**
 
 ```sh
-# Assign issues to the sprint milestone
-gh issue edit <issue-number> --milestone "Sprint 1"
+GH_PAGER=cat gh issue edit <issue-number> --milestone "Sprint 1"
 ```
 
 ### 5. Create Repository Scaffolding
@@ -545,8 +625,18 @@ When the user asks to plan a new sprint or the current sprint's milestone is clo
 
 1. **Review the backlog.** List issues with `status:ready` that have no milestone:
 
+   **Using MCP (preferred):**
+
+   ```
+   tool: mcp_github_github_search_issues
+   params:
+     q: "repo:<owner>/<repo> is:issue is:open label:status:ready no:milestone"
+   ```
+
+   **Using `gh` CLI (fallback):**
+
    ```sh
-   gh issue list --label "status:ready" --milestone "" --json number,title,labels --jq '.[] | "#\(.number) \(.title) [\(.labels | map(.name) | join(", "))]"'
+   GH_PAGER=cat gh issue list --label "status:ready" --milestone "" --json number,title,labels --jq '.[] | "#\(.number) \(.title) [\(.labels | map(.name) | join(", "))]"'
    ```
 
 2. **Propose a sprint selection.** Recommend issues based on:
@@ -559,24 +649,53 @@ When the user asks to plan a new sprint or the current sprint's milestone is clo
 
 4. **Create the milestone and assign issues:**
 
+   **Create milestone** (MCP does not support milestones — use `gh api`):
+
    ```sh
    # Get next sprint number
-   SPRINT_NUM=$(gh api repos/{owner}/{repo}/milestones --jq 'length + 1')
+   SPRINT_NUM=$(GH_PAGER=cat gh api repos/{owner}/{repo}/milestones --jq 'length + 1')
 
    # Create milestone
-   gh api repos/{owner}/{repo}/milestones --method POST \
+   GH_PAGER=cat gh api repos/{owner}/{repo}/milestones --method POST \
      --field title="Sprint ${SPRINT_NUM}" \
      --field description="Sprint Goal: <goal>" \
      --field due_on="<due date ISO 8601>"
+   ```
 
-   # Assign selected issues
-   gh issue edit <number> --milestone "Sprint ${SPRINT_NUM}"
+   **Assign issues using MCP (preferred):**
+
+   ```
+   tool: mcp_github_github_issue_write
+   params:
+     owner: <owner>
+     repo: <repo>
+     issue_number: <number>
+     milestone: <milestone-number>
+   ```
+
+   **Using `gh` CLI (fallback):**
+
+   ```sh
+   GH_PAGER=cat gh issue edit <number> --milestone "Sprint ${SPRINT_NUM}"
    ```
 
 5. **Mark issues as in-progress** when work begins:
 
+   **Using MCP (preferred):**
+
+   ```
+   tool: mcp_github_github_issue_write
+   params:
+     owner: <owner>
+     repo: <repo>
+     issue_number: <number>
+     labels: ["status:in-progress", ...other existing labels minus "status:ready"]
+   ```
+
+   **Using `gh` CLI (fallback):**
+
    ```sh
-   gh issue edit <number> --add-label "status:in-progress" --remove-label "status:ready"
+   GH_PAGER=cat gh issue edit <number> --add-label "status:in-progress" --remove-label "status:ready"
    ```
 
 ### During the Sprint
@@ -585,19 +704,50 @@ The agent can help with these activities at any time:
 
 - **Progress report.** Show sprint burndown:
 
+  **Using MCP (preferred):**
+
+  ```
+  tool: mcp_github_github_list_issues
+  params:
+    owner: <owner>
+    repo: <repo>
+    milestone: <milestone-number>
+    state: "open"
+  ```
+
+  ```
+  tool: mcp_github_github_list_issues
+  params:
+    owner: <owner>
+    repo: <repo>
+    milestone: <milestone-number>
+    state: "closed"
+  ```
+
+  **Using `gh` CLI (fallback):**
+
   ```sh
-  # Open vs closed issues in current sprint
   MILESTONE="Sprint N"
   echo "=== Open ==="
-  gh issue list --milestone "$MILESTONE" --state open --json number,title,labels -q '.[] | "#\(.number) \(.title)"'
+  GH_PAGER=cat gh issue list --milestone "$MILESTONE" --state open --json number,title,labels -q '.[] | "#\(.number) \(.title)"'
   echo "=== Closed ==="
-  gh issue list --milestone "$MILESTONE" --state closed --json number,title,labels -q '.[] | "#\(.number) \(.title)"'
+  GH_PAGER=cat gh issue list --milestone "$MILESTONE" --state closed --json number,title,labels -q '.[] | "#\(.number) \(.title)"'
   ```
 
 - **Identify blockers.** List blocked issues:
 
+  **Using MCP (preferred):**
+
+  ```
+  tool: mcp_github_github_search_issues
+  params:
+    q: "repo:<owner>/<repo> is:issue is:open label:status:blocked"
+  ```
+
+  **Using `gh` CLI (fallback):**
+
   ```sh
-  gh issue list --label "status:blocked" --json number,title,body -q '.[] | "#\(.number) \(.title)"'
+  GH_PAGER=cat gh issue list --label "status:blocked" --json number,title,body -q '.[] | "#\(.number) \(.title)"'
   ```
 
 - **Update status labels** as issues move through the workflow:
@@ -614,45 +764,98 @@ When the sprint ends (milestone due date reached or all issues closed):
 
 1. **List what was completed:**
 
+   **Using MCP (preferred):**
+
+   ```
+   tool: mcp_github_github_list_issues
+   params:
+     owner: <owner>
+     repo: <repo>
+     milestone: <milestone-number>
+     state: "closed"
+   ```
+
+   **Using `gh` CLI (fallback):**
+
    ```sh
-   gh issue list --milestone "Sprint N" --state closed --json number,title,closedAt \
+   GH_PAGER=cat gh issue list --milestone "Sprint N" --state closed --json number,title,closedAt \
      -q '.[] | "#\(.number) \(.title) (closed \(.closedAt | split("T")[0]))"'
    ```
 
 2. **Identify carryover** — issues not completed move back to the backlog:
 
+   **Using MCP (preferred):**
+
+   ```
+   # List uncompleted issues
+   tool: mcp_github_github_list_issues
+   params:
+     owner: <owner>
+     repo: <repo>
+     milestone: <milestone-number>
+     state: "open"
+
+   # Remove milestone from uncompleted issues (return to backlog)
+   tool: mcp_github_github_issue_write
+   params:
+     owner: <owner>
+     repo: <repo>
+     issue_number: <number>
+     milestone: null
+   ```
+
+   **Using `gh` CLI (fallback):**
+
    ```sh
    # List uncompleted issues
-   gh issue list --milestone "Sprint N" --state open --json number,title \
+   GH_PAGER=cat gh issue list --milestone "Sprint N" --state open --json number,title \
      -q '.[] | "#\(.number) \(.title)"'
 
    # Remove milestone from uncompleted issues (return to backlog)
-   gh issue edit <number> --milestone ""
+   GH_PAGER=cat gh issue edit <number> --milestone ""
    ```
 
 3. **Create a release** if there is a usable Increment:
 
+   > **Note:** The MCP server does not support release creation. Use `gh` CLI.
+
    ```sh
-   gh release create v<version> --title "Sprint N Release" \
-     --notes "## What's New\n\n$(gh issue list --milestone 'Sprint N' --state closed --json number,title -q '.[] | "- #\(.number) \(.title)"')\n\n## Sprint Goal\n\n<goal summary>"
+   GH_PAGER=cat gh release create v<version> --title "Sprint N Release" \
+     --notes "## What's New\n\n$(GH_PAGER=cat gh issue list --milestone 'Sprint N' --state closed --json number,title -q '.[] | "- #\(.number) \(.title)"')\n\n## Sprint Goal\n\n<goal summary>"
    ```
 
 4. **Close the milestone:**
 
+   > **Note:** The MCP server does not support milestone operations. Use `gh api`.
+
    ```sh
    # Get milestone number
-   MILESTONE_NUM=$(gh api repos/{owner}/{repo}/milestones --jq '.[] | select(.title=="Sprint N") | .number')
+   MILESTONE_NUM=$(GH_PAGER=cat gh api repos/{owner}/{repo}/milestones --jq '.[] | select(.title=="Sprint N") | .number')
 
    # Close it
-   gh api repos/{owner}/{repo}/milestones/${MILESTONE_NUM} --method PATCH --field state="closed"
+   GH_PAGER=cat gh api repos/{owner}/{repo}/milestones/${MILESTONE_NUM} --method PATCH --field state="closed"
    ```
 
 ### Sprint Retrospective
 
 After closing the sprint, create a retrospective issue:
 
+**Using MCP (preferred):**
+
+```
+tool: mcp_github_github_issue_write
+params:
+  owner: <owner>
+  repo: <repo>
+  title: "Retrospective: Sprint N"
+  body: "## What went well?\n\n- \n\n## What could be improved?\n\n- \n\n## Action items for next sprint\n\n- [ ] \n\n## Metrics\n\n- **Planned:** X issues\n- **Completed:** Y issues\n- **Carried over:** Z issues\n- **Sprint Goal met:** Yes/No"
+  labels: ["retrospective"]
+```
+
+**Using `gh` CLI (fallback):**
+
 ```sh
-gh issue create \
+GH_PAGER=cat gh issue create \
   --title "Retrospective: Sprint N" \
   --label "retrospective" \
   --body "## What went well?\n\n- \n\n## What could be improved?\n\n- \n\n## Action items for next sprint\n\n- [ ] \n\n## Metrics\n\n- **Planned:** X issues\n- **Completed:** Y issues\n- **Carried over:** Z issues\n- **Sprint Goal met:** Yes/No"
@@ -680,15 +883,45 @@ Issues labeled `size:xl` should be split. Help the user decompose them:
 3. Create new issues for each chunk (linked to original via "Part of #N")
 4. Close the original issue with a comment listing the sub-issues
 
+**Using MCP (preferred):**
+
+```
+# Create sub-issue
+tool: mcp_github_github_issue_write
+params:
+  owner: <owner>
+  repo: <repo>
+  title: "<specific sub-task>"
+  body: "Part of #<original-number>\n\n## Description\n\n<details>\n\n## Acceptance Criteria\n\n- [ ] <specific criterion>"
+  labels: ["type:feature", "priority:high", "size:m"]
+
+# Close original with comment
+tool: mcp_github_github_add_issue_comment
+params:
+  owner: <owner>
+  repo: <repo>
+  issue_number: <original-number>
+  body: "Split into #<sub1>, #<sub2>, #<sub3>"
+
+tool: mcp_github_github_issue_write
+params:
+  owner: <owner>
+  repo: <repo>
+  issue_number: <original-number>
+  state: "closed"
+```
+
+**Using `gh` CLI (fallback):**
+
 ```sh
 # Create sub-issue
-gh issue create \
+GH_PAGER=cat gh issue create \
   --title "<specific sub-task>" \
   --body "Part of #<original-number>\n\n## Description\n\n<details>\n\n## Acceptance Criteria\n\n- [ ] <specific criterion>" \
   --label "type:feature,priority:high,size:m"
 
 # Close original with reference
-gh issue close <original-number> --comment "Split into #<sub1>, #<sub2>, #<sub3>"
+GH_PAGER=cat gh issue close <original-number> --comment "Split into #<sub1>, #<sub2>, #<sub3>"
 ```
 
 ### Add Missing Details
@@ -700,10 +933,32 @@ For each issue that lacks acceptance criteria or has vague descriptions:
 3. Update the issue with the refined content
 4. Add `status:ready` label when fully refined
 
+**Using MCP (preferred):**
+
+```
+# Read the issue
+tool: mcp_github_github_issue_read
+params:
+  owner: <owner>
+  repo: <repo>
+  issue_number: <number>
+
+# Update issue body and labels
+tool: mcp_github_github_issue_write
+params:
+  owner: <owner>
+  repo: <repo>
+  issue_number: <number>
+  body: "<refined body with acceptance criteria>"
+  labels: [...existing labels, "status:ready"]
+```
+
+**Using `gh` CLI (fallback):**
+
 ```sh
 # Update issue body with refined content
-gh issue edit <number> --body "<refined body with acceptance criteria>"
-gh issue edit <number> --add-label "status:ready"
+GH_PAGER=cat gh issue edit <number> --body "<refined body with acceptance criteria>"
+GH_PAGER=cat gh issue edit <number> --add-label "status:ready"
 ```
 
 ### Reprioritize
@@ -715,8 +970,20 @@ Review the backlog ordering when:
 
 List the current backlog sorted by priority:
 
+**Using MCP (preferred):**
+
+```
+tool: mcp_github_github_search_issues
+params:
+  q: "repo:<owner>/<repo> is:issue is:open no:milestone"
+  sort: "created"
+  order: "desc"
+```
+
+**Using `gh` CLI (fallback):**
+
 ```sh
-gh issue list --state open --milestone "" --json number,title,labels \
+GH_PAGER=cat gh issue list --state open --milestone "" --json number,title,labels \
   -q 'sort_by(.labels | map(select(.name | startswith("priority:"))) | .[0].name) | .[] | "#\(.number) \(.title) [\(.labels | map(.name) | join(", "))]"'
 ```
 
@@ -744,60 +1011,100 @@ When the user says an issue is done, verify:
 2. **Check code quality** — run lint/tests if configured
 3. **Close the issue** with a reference:
 
+   **Using MCP (preferred):**
+
+   ```
+   tool: mcp_github_github_add_issue_comment
+   params:
+     owner: <owner>
+     repo: <repo>
+     issue_number: <number>
+     body: "Done in <commit-sha or PR #>"
+
+   tool: mcp_github_github_issue_write
+   params:
+     owner: <owner>
+     repo: <repo>
+     issue_number: <number>
+     state: "closed"
+   ```
+
+   **Using `gh` CLI (fallback):**
+
    ```sh
-   gh issue close <number> --comment "Done in <commit-sha or PR #>"
+   GH_PAGER=cat gh issue close <number> --comment "Done in <commit-sha or PR #>"
    ```
 
 If any criterion is not met, tell the user what's missing before closing.
 
 ---
 
-## `gh` CLI Reference
+## Reference
 
-### Labels
+### MCP Tools (preferred)
+
+| Operation | MCP Tool | Key Params |
+|---|---|---|
+| Create issue | `mcp_github_github_issue_write` | `owner`, `repo`, `title`, `body`, `labels` |
+| Update issue | `mcp_github_github_issue_write` | `owner`, `repo`, `issue_number`, + fields to update |
+| Read issue | `mcp_github_github_issue_read` | `owner`, `repo`, `issue_number` |
+| List issues | `mcp_github_github_list_issues` | `owner`, `repo`, `state`, `milestone`, `labels` |
+| Search issues | `mcp_github_github_search_issues` | `q` (GitHub search syntax) |
+| Add comment | `mcp_github_github_add_issue_comment` | `owner`, `repo`, `issue_number`, `body` |
+| Create PR | `mcp_github_github_create_pull_request` | `owner`, `repo`, `title`, `body`, `head`, `base` |
+| List PRs | `mcp_github_github_list_pull_requests` | `owner`, `repo`, `state` |
+| Merge PR | `mcp_github_github_merge_pull_request` | `owner`, `repo`, `pull_number` |
+| List releases | `mcp_github_github_list_releases` | `owner`, `repo` |
+| Get label | `mcp_github_github_get_label` | `owner`, `repo`, `name` |
+| Create branch | `mcp_github_github_create_branch` | `owner`, `repo`, `ref`, `sha` |
+| List branches | `mcp_github_github_list_branches` | `owner`, `repo` |
+
+### `gh` CLI (fallback — always use `GH_PAGER=cat`)
+
+#### Labels
 
 ```sh
-gh label create "<name>" --color "<hex>" --description "<text>"
-gh label delete "<name>" --yes
-gh label list
+GH_PAGER=cat gh label create "<name>" --color "<hex>" --description "<text>"
+GH_PAGER=cat gh label delete "<name>" --yes
+GH_PAGER=cat gh label list
 ```
 
-### Issues
+#### Issues
 
 ```sh
-gh issue create --title "<title>" --body "<body>" --label "<l1>,<l2>" --milestone "<name>"
-gh issue list --milestone "<name>" --state open --label "<label>"
-gh issue edit <number> --add-label "<label>" --remove-label "<label>"
-gh issue edit <number> --milestone "<name>"
-gh issue close <number> --comment "<reason>"
-gh issue view <number>
+GH_PAGER=cat gh issue create --title "<title>" --body "<body>" --label "<l1>,<l2>" --milestone "<name>"
+GH_PAGER=cat gh issue list --milestone "<name>" --state open --label "<label>"
+GH_PAGER=cat gh issue edit <number> --add-label "<label>" --remove-label "<label>"
+GH_PAGER=cat gh issue edit <number> --milestone "<name>"
+GH_PAGER=cat gh issue close <number> --comment "<reason>"
+GH_PAGER=cat gh issue view <number>
 ```
 
-### Milestones (via API)
+#### Milestones (via API)
 
 ```sh
 # List milestones
-gh api repos/{owner}/{repo}/milestones --jq '.[] | "\(.number): \(.title) (due: \(.due_on | split("T")[0]))"'
+GH_PAGER=cat gh api repos/{owner}/{repo}/milestones --jq '.[] | "\(.number): \(.title) (due: \(.due_on | split("T")[0]))"'
 
 # Create milestone
-gh api repos/{owner}/{repo}/milestones --method POST \
+GH_PAGER=cat gh api repos/{owner}/{repo}/milestones --method POST \
   --field title="Sprint N" \
   --field description="Sprint Goal: ..." \
   --field due_on="2026-03-06T23:59:59Z"
 
 # Close milestone
-gh api repos/{owner}/{repo}/milestones/<number> --method PATCH --field state="closed"
+GH_PAGER=cat gh api repos/{owner}/{repo}/milestones/<number> --method PATCH --field state="closed"
 
 # Update milestone
-gh api repos/{owner}/{repo}/milestones/<number> --method PATCH \
+GH_PAGER=cat gh api repos/{owner}/{repo}/milestones/<number> --method PATCH \
   --field description="Updated goal"
 ```
 
-### Releases
+#### Releases
 
 ```sh
-gh release create v<version> --title "<title>" --notes "<markdown>"
-gh release list
+GH_PAGER=cat gh release create v<version> --title "<title>" --notes "<markdown>"
+GH_PAGER=cat gh release list
 ```
 
 ---


### PR DESCRIPTION
## Summary

Update the `github-scrum` skill to prefer GitHub MCP tools (`mcp_github_github_*`) over `gh` CLI, and add `GH_PAGER=cat` to all `gh` CLI fallback commands.

## Changes

- **New "Tooling Strategy" section** documenting when to use MCP tools vs `gh` CLI
- **MCP-first for all supported operations**: issues (create, read, update, list, search, comment), PRs, branches
- **`GH_PAGER=cat` on every `gh` command** to prevent interactive pagers from blocking script execution
- **Clear fallback markers** with notes explaining why `gh` CLI is needed (labels, milestones, releases)
- **MCP reference table** at the bottom with all available tools and their key parameters

## Motivation

The GitHub MCP server provides a more reliable, structured interface for most GitHub operations. Using it as the primary tool avoids shell escaping issues, pager problems, and parsing complexity. The `gh` CLI remains as fallback only for operations the MCP server doesn't support (labels, milestones, releases).