### PR TITLE
fix(github-scrum): set contents permission to write in release-drafter workflow

### DIFF
--- a/skills/github-scrum/SKILL.md
+++ b/skills/github-scrum/SKILL.md
@@ -582,7 +582,7 @@ on:
     types: [opened, reopened, synchronize]
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
The release-drafter workflow needs `contents: write` (not `read`) to be able to create and update draft releases.